### PR TITLE
add WSL compose yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ docker-compose -f docker-compose-nvidia.yaml up
 ```
 
 If you have an AMD card or are running from a virtual machine use
-`docker-compose-nvidia.yaml` instead.
+`docker-compose-vmware.yaml` instead. For WSL use `docker-compose-wsl.yaml`
 
 You will need to provide the containers `xhost` access to you machine:
 `xhost +` will do this but there are serious security concerns. For a

--- a/docker-compose-wsl.yaml
+++ b/docker-compose-wsl.yaml
@@ -1,0 +1,99 @@
+version: '2.3'
+
+networks:
+  ros:
+    driver: bridge
+
+services:
+  ros-master:
+    image: rhysmainwaring/sail-sim
+    command: stdbuf -o L roscore
+    networks:
+      - ros
+    restart: always
+
+  gazebo:
+    image: rhysmainwaring/sail-sim
+    depends_on:
+      - ros-master
+    environment:
+      - "ROS_MASTER_URI=http://ros-master:11311"
+      - "ROS_HOSTNAME=gazebo"
+      - "DISPLAY"
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix:rw
+    command: stdbuf -o L roslaunch rs750_gazebo rs750_ocean_world.launch verbose:=true
+    networks:
+      - ros
+    restart: always
+
+  sail-controller:
+    image: rhysmainwaring/sail-sim
+    depends_on:
+      - ros-master
+    environment:
+      - "ROS_MASTER_URI=http://ros-master:11311"
+      - "ROS_HOSTNAME=sail-controller"
+    command: stdbuf -o L rosrun rs750_controller sail_controller
+    networks:
+      - ros
+    restart: always
+
+  twist-translate:
+    image: rhysmainwaring/sail-sim
+    depends_on:
+      - ros-master
+    environment:
+      - "ROS_MASTER_URI=http://ros-master:11311"
+      - "ROS_HOSTNAME=twist-translate"
+    command: stdbuf -o L rosrun rs750_controller twist_translate.py
+    networks:
+      - ros
+    restart: always
+
+  steering:
+    image: rhysmainwaring/sail-sim
+    depends_on:
+      - ros-master
+    environment:
+      - "ROS_MASTER_URI=http://ros-master:11311"
+      - "ROS_HOSTNAME=steering"
+      - "DISPLAY"
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix:rw
+    command: stdbuf -o L rosrun rqt_robot_steering rqt_robot_steering
+    networks:
+      - ros
+    restart: always
+
+  rviz:
+    image: rhysmainwaring/sail-sim
+    depends_on:
+      - ros-master
+    environment:
+      - "ROS_MASTER_URI=http://ros-master:11311"
+      - "ROS_HOSTNAME=rviz"
+      - "DISPLAY"
+    group_add:
+        - video
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix:rw
+    command: stdbuf -o L roslaunch rs750_viz view_robot.launch
+    networks:
+      - ros
+    restart: always
+
+  rqt:
+    image: rhysmainwaring/sail-sim
+    depends_on:
+      - ros-master
+    environment:
+      - "ROS_MASTER_URI=http://ros-master:11311"
+      - "ROS_HOSTNAME=rqt"
+      - "DISPLAY"
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix:rw
+    command: stdbuf -o L roslaunch rs750_viz view_robot_monitor.launch
+    networks:
+      - ros
+    restart: always


### PR DESCRIPTION
My first go a docker/gazebo/ros, but this yaml got it running on WSL2 Ubuntu-18.04.

Running, but only a few frames a second, (also running lots of other stuff so it might just be that) and I saw the ocean but no rs750 model was loaded, any ideas?

If we can get this running well on WSL my plan is to get it talking to ArduPilot SITL. We have some [gazebo support](https://ardupilot.org/dev/docs/using-gazebo-simulator-with-sitl.html) already so hopefully it will not be too tricky.